### PR TITLE
removes oneline restriction on echos

### DIFF
--- a/syntax/blade.vim
+++ b/syntax/blade.vim
@@ -13,9 +13,9 @@ runtime! syntax/php.vim
 silent! unlet b:current_syntax
 
 " Echos
-syn region bladeUnescapedEcho matchgroup=bladeEchoDelim start=/@\@<!\s*{!!/ end=/!!}\s*/ oneline contains=@phpClTop containedin=ALLBUT,bladeComment
-syn region bladeEscapedEcho matchgroup=bladeEchoDelim start=/@\@<!\s*{{{\@!/ end=/}}\s*/ oneline contains=@phpClTop containedin=ALLBUT,bladeComment
-syn region bladeEscapedEcho matchgroup=bladeEchoDelim start=/@\@<!\s*{{{{\@!/ end=/}}}/ oneline contains=@phpClTop containedin=ALLBUT,bladeComment
+syn region bladeUnescapedEcho matchgroup=bladeEchoDelim start=/@\@<!\s*{!!/ end=/!!}\s*/ contains=@phpClTop containedin=ALLBUT,bladeComment
+syn region bladeEscapedEcho matchgroup=bladeEchoDelim start=/@\@<!\s*{{{\@!/ end=/}}\s*/ contains=@phpClTop containedin=ALLBUT,bladeComment
+syn region bladeEscapedEcho matchgroup=bladeEchoDelim start=/@\@<!\s*{{{{\@!/ end=/}}}/ contains=@phpClTop containedin=ALLBUT,bladeComment
 
 " Structures
 syn match bladeStructure /\s*@\(else\|empty\|endfor\|endforeach\|endforelse\|endif\|endpush\|endsection\|endunless\|endwhile\|overwrite\|show\|stop\)\>/


### PR DESCRIPTION
This addresses the multiline issue noted here: https://github.com/xsbeats/vim-blade/issues/30

it only removes the `oneline` restriction on echo region definitions

![multiline](https://cloud.githubusercontent.com/assets/734348/8538415/45ba3050-2442-11e5-9a8d-2926dacc0b46.jpg)
