### PR TITLE
Fix indent syntax

### DIFF
--- a/indent/blade.vim
+++ b/indent/blade.vim
@@ -30,8 +30,11 @@ function! GetBladeIndent()
     let cindent = indent(v:lnum)
     if cline =~# '@\%(else\|elseif\|empty\|end\|show\)'
         let indent = cindent < indent ? cindent : indent - &sw
-    elseif HtmlIndent() > -1
-        let indent = HtmlIndent()
+    else
+        let hindent = HtmlIndent()
+        if hindent > -1
+            let indent = hindent
+        endif
     endif
     let increase = indent + &sw
     if indent = indent(lnum)

--- a/indent/blade.vim
+++ b/indent/blade.vim
@@ -11,7 +11,7 @@ let b:did_indent = 1
 
 setlocal autoindent
 setlocal indentexpr=GetBladeIndent()
-setlocal indentkeys=o,O,*<Return>,<>>,!^F,=@else,=@end,=@empty
+setlocal indentkeys=o,O,*<Return>,<>>,!^F,=@else,=@end,=@empty,=@show
 
 " Only define the function once.
 if exists("*GetBladeIndent")
@@ -28,7 +28,7 @@ function! GetBladeIndent()
     let cline = substitute(substitute(getline(v:lnum), '\s\+$', '', ''), '^\s\+', '', '')
     let indent = indent(lnum)
     let cindent = indent(v:lnum)
-    if cline =~# '@\%(else\|elseif\|empty\|end\)'
+    if cline =~# '@\%(else\|elseif\|empty\|end\|show\)'
         let indent = cindent < indent ? cindent : indent - &sw
     elseif HtmlIndent() > -1
         let indent = HtmlIndent()
@@ -38,7 +38,9 @@ function! GetBladeIndent()
         let indent = cindent <= indent ? -1 : increase
     endif
 
-    if line =~# '@\%(if\|elseif\|else\|unless\|foreach\|forelse\|for\|while\)\%(.*\s*@end\)\@!'
+    if line =~# '@\%(section\)\%(.*\s*@end\)\@!' && line !~# '@\%(section\)\s*([^,]*)'
+        return indent
+    elseif line =~# '@\%(if\|elseif\|else\|unless\|foreach\|forelse\|for\|while\|empty\|push\|section\)\%(.*\s*@end\)\@!'
         return increase
     else
         return indent

--- a/syntax/blade.vim
+++ b/syntax/blade.vim
@@ -23,8 +23,8 @@ syn region  bladeEcho       matchgroup=bladeDelimiter start="@\@<!{{" end="}}"  
 syn region  bladeEcho       matchgroup=bladeDelimiter start="{!!" end="!!}"  contains=@bladePhp,bladePhpParenBlock  containedin=ALLBUT,@bladeExempt keepend
 syn region  bladeComment    matchgroup=bladeDelimiter start="{{--" end="--}}"  contains=bladeTodo  containedin=ALLBUT,@bladeExempt keepend
 
-syn keyword bladeKeyword    @if @elseif @foreach @forelse @for @while @can @include @each @inject @extends @section @stack @push @unless nextgroup=bladePhpParenBlock skipwhite containedin=ALLBUT,@bladeExempt
-syn keyword bladeKeyword    @else @endif @endunless @endfor @endforeach @empty @endforelse @endwhile @endcan @stop @append @endsection @endpush containedin=ALLBUT,@bladeExempt
+syn keyword bladeKeyword    @if @elseif @foreach @forelse @for @while @can @include @each @inject @extends @section @stack @push @unless @yield @parent nextgroup=bladePhpParenBlock skipwhite containedin=ALLBUT,@bladeExempt
+syn keyword bladeKeyword    @else @endif @endunless @endfor @endforeach @empty @endforelse @endwhile @endcan @stop @append @endsection @endpush @show containedin=ALLBUT,@bladeExempt
 
 syn region  bladePhpParenBlock  matchgroup=bladeDelimiter start="\s*(" end=")" contains=@bladePhp,bladePhpParenBlock skipwhite contained
 

--- a/syntax/blade.vim
+++ b/syntax/blade.vim
@@ -31,6 +31,8 @@ syn region  bladePhpParenBlock  matchgroup=bladeDelimiter start="\s*(" end=")" c
 syn cluster bladePhp contains=@phpClTop
 syn cluster bladeExempt contains=bladeComment,@htmlTop
 
+syn cluster htmlPreproc add=bladeEcho,bladeComment
+
 syn keyword bladeTodo todo fixme xxx  contained
 
 hi def link bladeDelimiter      PreProc

--- a/test.blade.php
+++ b/test.blade.php
@@ -93,3 +93,5 @@ Hello, {!! $name !!}.
     @parent
     <p>This is appended to the master sidebar.</p>
 @endsection
+
+<input name="example" {{ old('example') ? 'checked' : '' }} />

--- a/test.blade.php
+++ b/test.blade.php
@@ -74,6 +74,22 @@ Hello, {!! $name !!}.
 
 <head>
     <!-- Head Contents -->
+    <title>Test - @yield('title')</title>
 
     @stack('scripts')
 </head>
+
+<div>
+    @section('sidebar')
+        This is the master sidebar.
+    @show
+
+    @yield('content')
+</div>
+
+@section('title', 'Page Title')
+
+@section('sidebar')
+    @parent
+    <p>This is appended to the master sidebar.</p>
+@endsection


### PR DESCRIPTION
Some fixes:

- Add syntax for @yield @parent and @show
- Add indent for @show @empty @push and @section
- Fix highlighting in html tags. Highlighting inside the HTML tags was not working. Example, to add a attribute:
`<input name="example" {{ old('example') ? 'checked' : '' }} />`
- Remove duplicate call to HtmlIndent. It was processing the indentation twice.