### PR TITLE
Add support to eclim indent

### DIFF
--- a/indent/blade.vim
+++ b/indent/blade.vim
@@ -31,7 +31,11 @@ function! GetBladeIndent()
     if cline =~# '@\%(else\|elseif\|empty\|end\|show\)'
         let indent = cindent < indent ? cindent : indent - &sw
     else
-        let hindent = HtmlIndent()
+        if exists("*GetBladeIndentCustom")
+            let hindent = GetBladeIndentCustom()
+        else
+            let hindent = HtmlIndent()
+        endif
         if hindent > -1
             let indent = hindent
         endif


### PR DESCRIPTION
Currently indentation is based on the function `HtmlIndent` which is the default.

But there are plugins that add their own indentation. The [eclim](http://eclim.org) is one of those.

It is good to give the user option to continue using HTML and PHP indenting of your favorite plugin and only add the Blade indentation.

I added a check to see which base indentation should follow, if none is defined or is not valid, will use the default `HtmlIndent`. It also checks if the required function exists.

For now I only know eclim, but if someone inform other cases like this, it will be easy to add.

This change does not alter the operation of anyone, even if you use the eclim.

If someone has the eclim and want to use the standard indentation eclim and only add the indentation blade, just add in your `.vimrc` the following line:

`let g:BladeIndentBase = 'eclim'`

The main difference in eclim indentation is that it increases the indentation when there is line break between attributes.

Default:

```
<input name="example"
value="example" />
```

Eclim:

```
<input name="example"
        value="example" />
```

It was this difference that I realized I had something was out of the pattern of other files.
