### PR TITLE
Support using 'gf' to go to an included view

### DIFF
--- a/ftplugin/blade.vim
+++ b/ftplugin/blade.vim
@@ -8,3 +8,7 @@ endif
 
 runtime! ftplugin/html.vim
 let b:did_ftplugin = 1
+
+setlocal suffixesadd=.blade.php,.php
+setlocal includeexpr=substitute(v:fname,'\\.','/','g')
+setlocal path+=resources/views;


### PR DESCRIPTION
This enables you to use the keystroke 'gf' to go to the included or extended view under the cursor, i.e. `@include('filename')`, `@extends('filename')`.

The semicolon after the path makes it possible to go to the file, even if your PWD is somewhere deeper in the project, e.g. `resources/views/frontend/pages` (see :help file-searching).

If anyone sees something that could be improved or added, let me know. Maybe we need to support Laravel 4 in the path variable?