### PR TITLE
Fix PHP indentation

### DIFF
--- a/indent/blade.vim
+++ b/indent/blade.vim
@@ -6,6 +6,7 @@ if exists("b:did_indent")
     finish
 endif
 runtime! indent/html.vim
+let s:htmlindent = &indentexpr
 unlet! b:did_indent
 let b:did_indent = 1
 
@@ -34,7 +35,7 @@ function! GetBladeIndent()
         if exists("*GetBladeIndentCustom")
             let hindent = GetBladeIndentCustom()
         else
-            let hindent = HtmlIndent()
+            execute 'let hindent = ' . s:htmlindent
         endif
         if hindent > -1
             let indent = hindent
@@ -47,7 +48,7 @@ function! GetBladeIndent()
 
     if line =~# '@\%(section\)\%(.*\s*@end\)\@!' && line !~# '@\%(section\)\s*([^,]*)'
         return indent
-    elseif line =~# '@\%(if\|elseif\|else\|unless\|foreach\|forelse\|for\|while\|empty\|push\|section\|can\)\%(.*\s*@end\)\@!'
+    elseif line =~# '@\%(if\|elseif\|else\|unless\|foreach\|forelse\|for\|while\|empty\|push\|section\|can\|hasSection\)\%(.*\s*@end\)\@!'
         return increase
     else
         return indent

--- a/indent/blade.vim
+++ b/indent/blade.vim
@@ -64,7 +64,7 @@ function! GetBladeIndent()
                 \ line =~# '{{\%(.*}}\)\@!' || line =~# '{!!\%(.*!!}\)\@!'
         return increase
     elseif line =~# '<?\%(.*?>\)\@!'
-        return indent(v:lnum - 1) + increase
+        return indent(lnum-1) == -1 ? increase : indent(lnum) + increase
     else
         return indent
     endif

--- a/indent/blade.vim
+++ b/indent/blade.vim
@@ -35,12 +35,16 @@ function! GetBladeIndent()
     let cline = substitute(substitute(getline(v:lnum), '\s\+$', '', ''), '^\s\+', '', '')
     let indent = indent(lnum)
     let cindent = indent(v:lnum)
-    if cline =~# '@\%(else\|elseif\|empty\|end\|show\)'
+    if cline =~# '@\%(else\|elseif\|empty\|end\|show\)' ||
+                \ cline =~# '\%(<?.*\)\@<!?>\|\%({{.*\)\@<!}}\|\%({!!.*\)\@<!!!}'
         let indent = indent - &sw
     else
         if exists("*GetBladeIndentCustom")
             let hindent = GetBladeIndentCustom()
-        elseif searchpair('@include\s*(', '', ')', 'bWr')
+        elseif searchpair('@include\s*(', '', ')', 'bWr') ||
+                    \ searchpair('{!!', '', '!!}', 'bWr') ||
+                    \ searchpair('{{', '', '}}', 'bWr') ||
+                    \ searchpair('<?', '', '?>', 'bWr')
             execute 'let hindent = ' . s:phpindent
         else
             execute 'let hindent = ' . s:htmlindent
@@ -56,8 +60,11 @@ function! GetBladeIndent()
 
     if line =~# '@\%(section\)\%(.*\s*@end\)\@!' && line !~# '@\%(section\)\s*([^,]*)'
         return indent
-    elseif line =~# '@\%(if\|elseif\|else\|unless\|foreach\|forelse\|for\|while\|empty\|push\|section\|can\|hasSection\)\%(.*\s*@end\)\@!'
+    elseif line =~# '@\%(if\|elseif\|else\|unless\|foreach\|forelse\|for\|while\|empty\|push\|section\|can\|hasSection\)\%(.*\s*@end\)\@!' ||
+                \ line =~# '{{\%(.*}}\)\@!' || line =~# '{!!\%(.*!!}\)\@!'
         return increase
+    elseif line =~# '<?\%(.*?>\)\@!'
+        return indent(v:lnum - 1) + increase
     else
         return indent
     endif

--- a/indent/blade.vim
+++ b/indent/blade.vim
@@ -5,9 +5,15 @@
 if exists("b:did_indent")
     finish
 endif
+
 runtime! indent/html.vim
 let s:htmlindent = &indentexpr
 unlet! b:did_indent
+
+runtime! indent/php.vim
+let s:phpindent = &indentexpr
+unlet! b:did_indent
+
 let b:did_indent = 1
 
 setlocal autoindent
@@ -34,6 +40,8 @@ function! GetBladeIndent()
     else
         if exists("*GetBladeIndentCustom")
             let hindent = GetBladeIndentCustom()
+        elseif searchpair('@include\s*(', '', ')', 'bWr')
+            execute 'let hindent = ' . s:phpindent
         else
             execute 'let hindent = ' . s:htmlindent
         endif

--- a/test.blade.php
+++ b/test.blade.php
@@ -101,3 +101,26 @@ Hello, {!! $name !!}.
 @endsection
 
 <input name="example" {{ old('example') ? 'checked' : '' }} />
+
+<?php
+    $collection = collect([
+        'foo' => [
+            'bar',
+            'baz',
+        ]
+    ])
+?>
+
+@include('pages.home', [
+    'foo' => [
+        'bar',
+        'baz',
+    ]
+])
+
+{{
+    sprintf(
+        'This %s a multiline echo statement',
+        $foo
+    )
+}}


### PR DESCRIPTION
I actually based this on the branch of @zcodes because he already had some code that I could use as an example. So when you're merging this, you might want to merge his changes first.

Also, when you're going to merge these pull requests, you will probably run into some conflicts. To get a hint on how these should be merged, you could take a look at [my master branch](https://github.com/adriaanzon/vim-blade/commits/master). I already have them merged there.

So, this pull request adds indentation for all multiline PHP statements. By that I mean everything in between `<?php ?>`, `{{ }}`, `{!! !!}` and also between the parentheses of `@include()` (for when you pass a large array to an included view).

The only place where it doesn't work properly yet, is when you have a function call inside `@include()`. It will falsely recognize the closing parenthesis of the function call as the closing parenthesis of the include statement. If someone knows how to solve this, that would be nice. But I already think it is a lot better than no indentation at all, and most of the time you won't have a function call inside an include statement anyway.