### PR TITLE
Further enhancements to PHP indentation

### DIFF
--- a/indent/blade.vim
+++ b/indent/blade.vim
@@ -38,6 +38,8 @@ function! GetBladeIndent()
     if cline =~# '@\%(else\|elseif\|empty\|end\|show\|stop\)' ||
                 \ cline =~# '\%(<?.*\)\@<!?>\|\%({{.*\)\@<!}}\|\%({!!.*\)\@<!!!}'
         let indent = indent - &sw
+    elseif line =~# '<?\%(.*?>\)\@!'
+        let indent = indent + &sw
     else
         if exists("*GetBladeIndentCustom")
             let hindent = GetBladeIndentCustom()
@@ -63,8 +65,6 @@ function! GetBladeIndent()
     elseif line =~# '@\%(if\|elseif\|else\|unless\|foreach\|forelse\|for\|while\|empty\|push\|section\|can\|hasSection\)\%(.*@end\|.*@stop\)\@!' ||
                 \ line =~# '{{\%(.*}}\)\@!' || line =~# '{!!\%(.*!!}\)\@!'
         return increase
-    elseif line =~# '<?\%(.*?>\)\@!'
-        return indent(lnum-1) == -1 ? increase : indent(lnum) + increase
     else
         return indent
     endif

--- a/indent/blade.vim
+++ b/indent/blade.vim
@@ -34,7 +34,6 @@ function! GetBladeIndent()
     let line = substitute(substitute(getline(lnum), '\s\+$', '', ''), '^\s\+', '', '')
     let cline = substitute(substitute(getline(v:lnum), '\s\+$', '', ''), '^\s\+', '', '')
     let indent = indent(lnum)
-    let cindent = indent(v:lnum)
     if cline =~# '@\%(else\|elseif\|empty\|end\|show\|stop\)' ||
                 \ cline =~# '\%(<?.*\)\@<!?>\|\%({{.*\)\@<!}}\|\%({!!.*\)\@<!!!}'
         let indent = indent - &sw
@@ -56,9 +55,6 @@ function! GetBladeIndent()
         endif
     endif
     let increase = indent + &sw
-    if indent = indent(lnum)
-        let indent = cindent <= indent ? -1 : increase
-    endif
 
     if line =~# '@\%(section\)\%(.*@end\)\@!' && line !~# '@\%(section\)\s*([^,]*)'
         return indent


### PR DESCRIPTION
I simplified the indentation rule for detecting `<?php`. It seems to work better now when there's a `<?php` block at the beginning of a file.

`searchpair()` now skips matches that are inside a string or comment.

I also removed the unneeded conditional i mentioned [here](https://github.com/jwalton512/vim-blade/issues/42#issuecomment-227264663).
