### PR TITLE
Use 'syn iskeyword' instead of 'setlocal iskeyword'

### DIFF
--- a/ftplugin/blade.vim
+++ b/ftplugin/blade.vim
@@ -8,5 +8,3 @@ endif
 
 runtime! ftplugin/html.vim
 let b:did_ftplugin = 1
-
-setlocal iskeyword+=@-@

--- a/syntax/blade.vim
+++ b/syntax/blade.vim
@@ -19,6 +19,8 @@ unlet! b:current_syntax
 syn case match
 syn clear htmlError
 
+syn iskeyword @,@-@
+
 syn region  bladeEcho       matchgroup=bladeDelimiter start="@\@<!{{" end="}}"  contains=@bladePhp,bladePhpParenBlock  containedin=ALLBUT,@bladeExempt keepend
 syn region  bladeEcho       matchgroup=bladeDelimiter start="{!!" end="!!}"  contains=@bladePhp,bladePhpParenBlock  containedin=ALLBUT,@bladeExempt keepend
 syn region  bladeComment    matchgroup=bladeDelimiter start="{{--" end="--}}"  contains=bladeTodo  containedin=ALLBUT,@bladeExempt keepend


### PR DESCRIPTION
Changing the `iskeyword` option affects the behavior of some vim functions like `*`.  I also experienced an issue with this when configuring [vim-endwise](https://github.com/tpope/vim-endwise) for blade.

Using `syn iskeyword` is also recommended in `:help syn-iskeyword`.