### PR TITLE
Add missing characters to 'iskeyword'

### DIFF
--- a/syntax/blade.vim
+++ b/syntax/blade.vim
@@ -19,7 +19,7 @@ unlet! b:current_syntax
 syn case match
 syn clear htmlError
 
-syn iskeyword @,@-@
+syn iskeyword @,48-57,_,192-255,@-@
 
 syn region  bladeEcho       matchgroup=bladeDelimiter start="@\@<!{{" end="}}"  contains=@bladePhp,bladePhpParenBlock  containedin=ALLBUT,@bladeExempt keepend
 syn region  bladeEcho       matchgroup=bladeDelimiter start="{!!" end="!!}"  contains=@bladePhp,bladePhpParenBlock  containedin=ALLBUT,@bladeExempt keepend

--- a/syntax/blade.vim
+++ b/syntax/blade.vim
@@ -19,7 +19,11 @@ unlet! b:current_syntax
 syn case match
 syn clear htmlError
 
-syn iskeyword @,48-57,_,192-255,@-@
+if has('patch-7.4.1142')
+    syn iskeyword @,48-57,_,192-255,@-@
+else
+    setlocal iskeyword+=@-@
+endif
 
 syn region  bladeEcho       matchgroup=bladeDelimiter start="@\@<!{{" end="}}"  contains=@bladePhp,bladePhpParenBlock  containedin=ALLBUT,@bladeExempt keepend
 syn region  bladeEcho       matchgroup=bladeDelimiter start="{!!" end="!!}"  contains=@bladePhp,bladePhpParenBlock  containedin=ALLBUT,@bladeExempt keepend


### PR DESCRIPTION
My previous commit (fc9fceb) broke the highlighting of keywords with numbers in it (e.g. h1-h6).  I changed it to the default value of `iskeyword` plus `@-@`