### PR TITLE
Fix resetting of PHP indentation

### DIFF
--- a/indent/blade.vim
+++ b/indent/blade.vim
@@ -18,7 +18,7 @@ let b:did_indent = 1
 
 setlocal autoindent
 setlocal indentexpr=GetBladeIndent()
-setlocal indentkeys=o,O,*<Return>,<>>,!^F,=@else,=@end,=@empty,=@show,=@stop
+setlocal indentkeys=o,O,<>>,!^F,0=}},0=!!},=@else,=@end,=@empty,=@show,=@stop
 
 " Only define the function once.
 if exists("*GetBladeIndent")
@@ -42,10 +42,12 @@ function! GetBladeIndent()
     else
         if exists("*GetBladeIndentCustom")
             let hindent = GetBladeIndentCustom()
-        elseif searchpair('@include\s*(', '', ')', 'bWr') ||
+        " Don't use PHP indentation if line is a comment
+        elseif line !~# '^\s*\%(#\|//\)\|\*/\s*$' && (
+                    \ searchpair('@include\s*(', '', ')', 'bWr') ||
                     \ searchpair('{!!', '', '!!}', 'bWr') ||
                     \ searchpair('{{', '', '}}', 'bWr') ||
-                    \ searchpair('<?', '', '?>', 'bWr')
+                    \ searchpair('<?', '', '?>', 'bWr') )
             execute 'let hindent = ' . s:phpindent
         else
             execute 'let hindent = ' . s:htmlindent


### PR DESCRIPTION
There were a few problems with the PHP indentation resetting to 0.

- When you pressed return after typing `<?php`:
  Removing `*<Return>` from indentkeys solved this.  When you press
  return now, the next line still gets indented, but the current line
  doesn't get reindented anymore.  I don't think you will need this
  behavior very often so think it is safe to remove.

- When there was a comment on the first line of a PHP block:
  The indentation on the next line got reset when the first line of a
  PHP block was a comment. Fixed this by skipping `searchpair` if the
  line is a comment.

I added `0=}},0=!!}` to indentkeys, which reindents the line when you
type `}}` or `!!}` at the beginning of a line (ignoring whitespace).