### PR TITLE
Let vim know about various language constructs

### DIFF
--- a/ftplugin/blade.vim
+++ b/ftplugin/blade.vim
@@ -12,3 +12,21 @@ let b:did_ftplugin = 1
 setlocal suffixesadd=.blade.php,.php
 setlocal includeexpr=substitute(v:fname,'\\.','/','g')
 setlocal path+=resources/views;
+setlocal include=\\w\\@<!@\\%(include\\\|extends\\)
+setlocal define=\\w\\@<!@\\%(yield\\\|stack\\)
+
+setlocal commentstring={{--%s--}}
+setlocal comments+=s:{{--,m:\ \ \ \ ,e:--}}
+
+if exists('loaded_matchit') && exists('b:match_words')
+    " Append to html matchit words
+    let b:match_words .= ',' .
+                \ '@\%(section\|if\|unless\|foreach\|forelse\|for\|while\|push\|can\|cannot\|hasSection\|php\|verbatim\)\>' .
+                \ ':' .
+                \ '@\%(else\|elseif\|empty\|break\|continue\|elsecan\|elsecannot\)\>' .
+                \ ':' .
+                \ '@\%(end\w\+\|stop\|show\|append\|overwrite\)' .
+                \ ',{:},\[:\],(:)'
+    let b:match_skip = 'synIDattr(synID(line("."), col("."), 0), "name") !=# "bladeKeyword"'
+    let b:match_ignorecase = 0
+endif


### PR DESCRIPTION
- include: Lets vim know about the files that are included and extended
- define: Allows you to use `[<C-d>` to jump to the definition of a
  section or stack.  Example: using it on `@section('content')` would jump
  to `@yield('content')`     (looks through included files)
- added 'commentstring' and 'comments' options
- added support for matchit.vim (Notice the blade directives that aren't in
  the syntax/indent files yet, I'll probably add them soon. I'm currently experimenting
  with support for custom blade directives.)