### PR TITLE
Support custom blade directives and add missing ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,23 @@ Using pathogen
     cd ~/.vim/bundle
     git clone git://github.com/jwalton512/vim-blade.git
 
+Configuration
+-------------
+
+Because Blade allows you to define your own directives, you can let the plugin
+know about them through some variables. Examples:
+
+```vim
+" Define some single Blade directives. This variable is used for highlighting only.
+let g:blade_custom_directives = ['datetime', 'javascript']
+
+" Define pairs of Blade directives. This variable is used for highlighting and indentation.
+let g:blade_custom_directives_pairs = {
+      \   'markdown': 'endmarkdown',
+      \   'cache': 'endcache',
+      \ }
+```
+
 Contributing
 ------------
 

--- a/indent/blade.vim
+++ b/indent/blade.vim
@@ -16,9 +16,18 @@ unlet! b:did_indent
 
 let b:did_indent = 1
 
+" Doesn't include 'foreach' and 'forelse' because these already get matched by 'for'.
+let s:directives_start = 'if\|else\|unless\|for\|while\|empty\|push\|section\|can\|hasSection'
+let s:directives_end = 'else\|end\|empty\|show\|stop'
+
+if exists('g:blade_custom_directives_pairs')
+    let s:directives_start .= '\|' . join(keys(g:blade_custom_directives_pairs), '\|')
+    let s:directives_end .= '\|' . join(values(g:blade_custom_directives_pairs), '\|')
+endif
+
 setlocal autoindent
 setlocal indentexpr=GetBladeIndent()
-setlocal indentkeys=o,O,<>>,!^F,0=}},0=!!},=@else,=@end,=@empty,=@show,=@stop
+exe "setlocal indentkeys=o,O,<>>,!^F,0=}},0=!!},=@" . substitute(s:directives_end, '\\|', ',=@', 'g')
 
 " Only define the function once.
 if exists("*GetBladeIndent")
@@ -34,7 +43,7 @@ function! GetBladeIndent()
     let line = substitute(substitute(getline(lnum), '\s\+$', '', ''), '^\s\+', '', '')
     let cline = substitute(substitute(getline(v:lnum), '\s\+$', '', ''), '^\s\+', '', '')
     let indent = indent(lnum)
-    if cline =~# '@\%(else\|elseif\|empty\|end\|show\|stop\)' ||
+    if cline =~# '@\%(' . s:directives_end . '\)' ||
                 \ cline =~# '\%(<?.*\)\@<!?>\|\%({{.*\)\@<!}}\|\%({!!.*\)\@<!!!}'
         let indent = indent - &sw
     elseif line =~# '<?\%(.*?>\)\@!'
@@ -60,7 +69,7 @@ function! GetBladeIndent()
 
     if line =~# '@\%(section\)\%(.*@end\)\@!' && line !~# '@\%(section\)\s*([^,]*)'
         return indent
-    elseif line =~# '@\%(if\|elseif\|else\|unless\|foreach\|forelse\|for\|while\|empty\|push\|section\|can\|hasSection\)\%(.*@end\|.*@stop\)\@!' ||
+    elseif line =~# '@\%(' . s:directives_start . '\)\%(.*@end\|.*@stop\)\@!' ||
                 \ line =~# '{{\%(.*}}\)\@!' || line =~# '{!!\%(.*!!}\)\@!'
         return increase
     else

--- a/indent/blade.vim
+++ b/indent/blade.vim
@@ -46,7 +46,7 @@ function! GetBladeIndent()
     if cline =~# '@\%(' . s:directives_end . '\)' ||
                 \ cline =~# '\%(<?.*\)\@<!?>\|\%({{.*\)\@<!}}\|\%({!!.*\)\@<!!!}'
         let indent = indent - &sw
-    elseif line =~# '<?\%(.*?>\)\@!'
+    elseif line =~# '<?\%(.*?>\)\@!\|@php\%(\s*(\)\@!'
         let indent = indent + &sw
     else
         if exists("*GetBladeIndentCustom")
@@ -56,7 +56,8 @@ function! GetBladeIndent()
                     \ searchpair('@include\s*(', '', ')', 'bWr') ||
                     \ searchpair('{!!', '', '!!}', 'bWr') ||
                     \ searchpair('{{', '', '}}', 'bWr') ||
-                    \ searchpair('<?', '', '?>', 'bWr') )
+                    \ searchpair('<?', '', '?>', 'bWr') ||
+                    \ searchpair('@php\%(\s*(\)\@!', '', '@endphp', 'bWr') )
             execute 'let hindent = ' . s:phpindent
         else
             execute 'let hindent = ' . s:htmlindent

--- a/indent/blade.vim
+++ b/indent/blade.vim
@@ -17,8 +17,8 @@ unlet! b:did_indent
 let b:did_indent = 1
 
 " Doesn't include 'foreach' and 'forelse' because these already get matched by 'for'.
-let s:directives_start = 'if\|else\|unless\|for\|while\|empty\|push\|section\|can\|hasSection'
-let s:directives_end = 'else\|end\|empty\|show\|stop'
+let s:directives_start = 'if\|else\|unless\|for\|while\|empty\|push\|section\|can\|hasSection\|verbatim'
+let s:directives_end = 'else\|end\|empty\|show\|stop\|append\|overwrite'
 
 if exists('g:blade_custom_directives_pairs')
     let s:directives_start .= '\|' . join(keys(g:blade_custom_directives_pairs), '\|')
@@ -53,7 +53,7 @@ function! GetBladeIndent()
             let hindent = GetBladeIndentCustom()
         " Don't use PHP indentation if line is a comment
         elseif line !~# '^\s*\%(#\|//\)\|\*/\s*$' && (
-                    \ searchpair('@include\s*(', '', ')', 'bWr') ||
+                    \ searchpair('@include\%(If\)\?\s*(', '', ')', 'bWr') ||
                     \ searchpair('{!!', '', '!!}', 'bWr') ||
                     \ searchpair('{{', '', '}}', 'bWr') ||
                     \ searchpair('<?', '', '?>', 'bWr') ||

--- a/syntax/blade.vim
+++ b/syntax/blade.vim
@@ -50,7 +50,8 @@ syn cluster bladeExempt contains=bladeComment,bladePhpRegion,bladePhpParenBlock,
 
 syn cluster htmlPreproc add=bladeEcho,bladeComment,bladePhpRegion
 
-syn keyword bladeTodo todo fixme xxx  contained
+syn case ignore
+syn keyword bladeTodo todo fixme xxx note  contained
 
 hi def link bladeDelimiter      PreProc
 hi def link bladeComment        Comment

--- a/syntax/blade.vim
+++ b/syntax/blade.vim
@@ -40,12 +40,15 @@ if exists('g:blade_custom_directives_pairs')
     exe "syn keyword bladeKeyword @" . join(values(g:blade_custom_directives_pairs), ' @') . " containedin=ALLBUT,@bladeExempt"
 endif
 
+syn region  bladePhpRegion  matchgroup=bladeKeyword start="\<@php\>\%(\s*(\)\@!" end="\<@endphp\>"  contains=@bladePhp  containedin=ALLBUT,@bladeExempt keepend
+syn match   bladeKeyword "@php\ze\s*(" nextgroup=bladePhpParenBlock skipwhite containedin=ALLBUT,@bladeExempt
+
 syn region  bladePhpParenBlock  matchgroup=bladeDelimiter start="\s*(" end=")" contains=@bladePhp,bladePhpParenBlock skipwhite contained
 
 syn cluster bladePhp contains=@phpClTop
-syn cluster bladeExempt contains=bladeComment,@htmlTop
+syn cluster bladeExempt contains=bladeComment,bladePhpRegion,bladePhpParenBlock,@htmlTop
 
-syn cluster htmlPreproc add=bladeEcho,bladeComment
+syn cluster htmlPreproc add=bladeEcho,bladeComment,bladePhpRegion
 
 syn keyword bladeTodo todo fixme xxx  contained
 

--- a/syntax/blade.vim
+++ b/syntax/blade.vim
@@ -32,6 +32,14 @@ syn region  bladeComment    matchgroup=bladeDelimiter start="{{--" end="--}}"  c
 syn keyword bladeKeyword    @if @elseif @foreach @forelse @for @while @can @include @each @inject @extends @section @stack @push @unless @yield @parent @hasSection nextgroup=bladePhpParenBlock skipwhite containedin=ALLBUT,@bladeExempt
 syn keyword bladeKeyword    @else @endif @endunless @endfor @endforeach @empty @endforelse @endwhile @endcan @stop @append @endsection @endpush @show containedin=ALLBUT,@bladeExempt
 
+if exists('g:blade_custom_directives')
+    exe "syn keyword bladeKeyword @" . join(g:blade_custom_directives, ' @') . " nextgroup=bladePhpParenBlock skipwhite containedin=ALLBUT,@bladeExempt"
+endif
+if exists('g:blade_custom_directives_pairs')
+    exe "syn keyword bladeKeyword @" . join(keys(g:blade_custom_directives_pairs), ' @') . " nextgroup=bladePhpParenBlock skipwhite containedin=ALLBUT,@bladeExempt"
+    exe "syn keyword bladeKeyword @" . join(values(g:blade_custom_directives_pairs), ' @') . " containedin=ALLBUT,@bladeExempt"
+endif
+
 syn region  bladePhpParenBlock  matchgroup=bladeDelimiter start="\s*(" end=")" contains=@bladePhp,bladePhpParenBlock skipwhite contained
 
 syn cluster bladePhp contains=@phpClTop

--- a/syntax/blade.vim
+++ b/syntax/blade.vim
@@ -29,8 +29,8 @@ syn region  bladeEcho       matchgroup=bladeDelimiter start="@\@<!{{" end="}}"  
 syn region  bladeEcho       matchgroup=bladeDelimiter start="{!!" end="!!}"  contains=@bladePhp,bladePhpParenBlock  containedin=ALLBUT,@bladeExempt keepend
 syn region  bladeComment    matchgroup=bladeDelimiter start="{{--" end="--}}"  contains=bladeTodo  containedin=ALLBUT,@bladeExempt keepend
 
-syn keyword bladeKeyword    @if @elseif @foreach @forelse @for @while @can @include @each @inject @extends @section @stack @push @unless @yield @parent @hasSection nextgroup=bladePhpParenBlock skipwhite containedin=ALLBUT,@bladeExempt
-syn keyword bladeKeyword    @else @endif @endunless @endfor @endforeach @empty @endforelse @endwhile @endcan @stop @append @endsection @endpush @show containedin=ALLBUT,@bladeExempt
+syn keyword bladeKeyword    @if @elseif @foreach @forelse @for @while @can @cannot @elsecan @elsecannot @include @includeIf @each @inject @extends @section @stack @push @unless @yield @parent @hasSection @break @continue @unset @lang @choice nextgroup=bladePhpParenBlock skipwhite containedin=ALLBUT,@bladeExempt
+syn keyword bladeKeyword    @else @endif @endunless @endfor @endforeach @empty @endforelse @endwhile @endcan @endcannot @stop @append @endsection @endpush @show @overwrite @verbatim @endverbatim containedin=ALLBUT,@bladeExempt
 
 if exists('g:blade_custom_directives')
     exe "syn keyword bladeKeyword @" . join(g:blade_custom_directives, ' @') . " nextgroup=bladePhpParenBlock skipwhite containedin=ALLBUT,@bladeExempt"

--- a/syntax/blade.vim
+++ b/syntax/blade.vim
@@ -20,7 +20,7 @@ syn case match
 syn clear htmlError
 
 if has('patch-7.4.1142')
-    syn iskeyword @,48-57,_,192-255,@-@
+    syn iskeyword @,48-57,_,192-255,@-@,:
 else
     setlocal iskeyword+=@-@
 endif

--- a/test.blade.php
+++ b/test.blade.php
@@ -138,6 +138,7 @@ Hello, {!! $name !!}.
 @cache
     A custom Blade directive
     @datetime($var)
+    @namespaced::directive($var)
 @endcache
 
 @php($var = 'Hello World')

--- a/test.blade.php
+++ b/test.blade.php
@@ -129,3 +129,12 @@ Hello, {!! $name !!}.
     A custom Blade directive
     @datetime($var)
 @endcache
+
+@php($var = 'Hello World')
+@unset($var)
+
+@php
+    $environment = isset($env) ? $env : 'testing';
+@endphp
+
+do_not_highlight@php.net

--- a/test.blade.php
+++ b/test.blade.php
@@ -124,3 +124,8 @@ Hello, {!! $name !!}.
         $foo
     )
 }}
+
+@cache
+    A custom Blade directive
+    @datetime($var)
+@endcache

--- a/test.blade.php
+++ b/test.blade.php
@@ -74,7 +74,7 @@ Hello, {!! $name !!}.
     @yield('dont highlight')
 --}}
 
-{{-- todo fixme xxx --}}
+{{-- todo fixme xxx note TODO FIXME XXX NOTE --}}
 
 @inject('metrics', 'App\Services\MetricsService')
 

--- a/test.blade.php
+++ b/test.blade.php
@@ -29,6 +29,8 @@ Hello, {!! $name !!}.
 
 @foreach ($users as $user)
     <p>This is user {{ $user->id }}</p>
+    @break
+    @continue
 @endforeach
 
 @forelse ($users as $user)
@@ -43,9 +45,17 @@ Hello, {!! $name !!}.
 
 @can('update-post', $post)
     <!-- current user can update the post -->
+@elsecan('delete-post', $post)
+    <!-- current user can delete the post -->
 @else
-    <!-- current user can't update the post -->
+    <!-- current user can't update or delete the post -->
 @endcan
+
+@cannot('view-post')
+    <!-- current user cannot view the post -->
+@elsecannot('publish-post')
+    <!-- current user cannot publish the post -->
+@endcannot
 
 <div>
     @include('shared.errors')
@@ -138,3 +148,12 @@ Hello, {!! $name !!}.
 @endphp
 
 do_not_highlight@php.net
+
+@verbatim
+    <p class="highlighted">@if(true) {{ $notHighlighted }} @endif</p>
+    <!-- highlighted -->
+    <?php /* also highlighted */ ?>
+@endverbatim
+
+@lang('messages.welcome')
+@choice('messages.items', 3)

--- a/vimrc
+++ b/vimrc
@@ -25,3 +25,6 @@ set nowrap
 map <F10> :echo "hi<" . synIDattr(synID(line("."),col("."),1),"name") . '> trans<'
             \ . synIDattr(synID(line("."),col("."),0),"name") . "> lo<"
             \ . synIDattr(synIDtrans(synID(line("."),col("."),1)),"name") . ">"<CR>
+
+let g:blade_custom_directives = ['datetime']
+let g:blade_custom_directives_pairs = {'cache': 'endcache'}

--- a/vimrc
+++ b/vimrc
@@ -26,5 +26,5 @@ map <F10> :echo "hi<" . synIDattr(synID(line("."),col("."),1),"name") . '> trans
             \ . synIDattr(synID(line("."),col("."),0),"name") . "> lo<"
             \ . synIDattr(synIDtrans(synID(line("."),col("."),1)),"name") . ">"<CR>
 
-let g:blade_custom_directives = ['datetime']
+let g:blade_custom_directives = ['datetime', 'namespaced::directive']
 let g:blade_custom_directives_pairs = {'cache': 'endcache'}


### PR DESCRIPTION
### Custom directives
Blade allows for custom directives so now you can define those through some variables (`g:blade_custom_directives` and `g:blade_custom_directives_pairs`).

### Missing directives
Added blade directives `@elsecan`, `@cannot`, `@elsecannot`, `@endcannot`, `@lang`, `@choice`, `@break`, `@continue`, `@verbatim`, `@endverbatim`.

Added indent for `@append` and `@overwrite`

Added support for @php (both the multiline and single line variants)

I tried to make a `syntax region` for `@verbatim`, and only highlight html tags and `<?php` tags in that region, but it did'nt really work well so I just added it to the bladeKeywords group for now. I did add tests for how it should be.

### Other stuff
Add `note` to todo comments and allow those comments to be uppercase.

A recent change to blade allows for :: in directives, added support for that.