### PR TITLE
Indent file refactor and various fixes

### DIFF
--- a/ftplugin/blade.vim
+++ b/ftplugin/blade.vim
@@ -21,8 +21,8 @@ setlocal comments+=s:{{--,m:\ \ \ \ ,e:--}}
 if exists('loaded_matchit') && exists('b:match_words')
     " Append to html matchit words
     let b:match_words .= ',' .
-                \ '@\%(section\|if\|unless\|foreach\|forelse\|for\|while\|push\|can\|cannot\|hasSection\|php\|' .
-                \     'verbatim\|component\|slot\)\>' .
+                \ '@\%(section\s*([^\,]*)\|if\|unless\|foreach\|forelse\|for\|while\|push\|can\|cannot\|hasSection\|' .
+                \     'php\s*(\@!\|verbatim\|component\|slot\)' .
                 \ ':' .
                 \ '@\%(else\|elseif\|empty\|break\|continue\|elsecan\|elsecannot\)\>' .
                 \ ':' .

--- a/ftplugin/blade.vim
+++ b/ftplugin/blade.vim
@@ -21,7 +21,8 @@ setlocal comments+=s:{{--,m:\ \ \ \ ,e:--}}
 if exists('loaded_matchit') && exists('b:match_words')
     " Append to html matchit words
     let b:match_words .= ',' .
-                \ '@\%(section\|if\|unless\|foreach\|forelse\|for\|while\|push\|can\|cannot\|hasSection\|php\|verbatim\)\>' .
+                \ '@\%(section\|if\|unless\|foreach\|forelse\|for\|while\|push\|can\|cannot\|hasSection\|php\|' .
+                \     'verbatim\|component\|slot\)\>' .
                 \ ':' .
                 \ '@\%(else\|elseif\|empty\|break\|continue\|elsecan\|elsecannot\)\>' .
                 \ ':' .

--- a/indent/blade.vim
+++ b/indent/blade.vim
@@ -16,7 +16,8 @@ let s:phpindent = &indentexpr
 let b:did_indent = 1
 
 " Doesn't include 'foreach' and 'forelse' because these already get matched by 'for'.
-let s:directives_start = 'if\|else\|unless\|for\|while\|empty\|push\|section\|can\|hasSection\|verbatim\|php'
+let s:directives_start = 'if\|else\|unless\|for\|while\|empty\|push\|section\|can\|hasSection\|verbatim\|php\|' .
+            \ 'component\|slot'
 let s:directives_end = 'else\|end\|empty\|show\|stop\|append\|overwrite'
 
 if exists('g:blade_custom_directives_pairs')

--- a/indent/blade.vim
+++ b/indent/blade.vim
@@ -84,7 +84,7 @@ function! GetBladeIndent()
                 \ searchpair('{!!', '', '!!}', 'bWr') ||
                 \ searchpair('{{', '', '}}', 'bWr') ||
                 \ searchpair('<?', '', '?>', 'bWr') ||
-                \ searchpair('@php\%(\s*(\)\@!', '', '@endphp', 'bWr') )
+                \ searchpair('@php\s*(\@!', '', '@endphp', 'bWr') )
         " Only use PHP's indent if the region spans multiple lines
         if !s:IsStartingDelimiter(v:lnum)
             execute 'let indent = ' . s:phpindent

--- a/indent/blade.vim
+++ b/indent/blade.vim
@@ -2,22 +2,21 @@
 " Language:     Blade (Laravel)
 " Maintainer:   Jason Walton <jwalton512@gmail.com>
 
-if exists("b:did_indent")
+if exists('b:did_indent')
     finish
 endif
 
 runtime! indent/html.vim
 let s:htmlindent = &indentexpr
-unlet! b:did_indent
 
+unlet! b:did_indent
 runtime! indent/php.vim
 let s:phpindent = &indentexpr
-unlet! b:did_indent
 
 let b:did_indent = 1
 
 " Doesn't include 'foreach' and 'forelse' because these already get matched by 'for'.
-let s:directives_start = 'if\|else\|unless\|for\|while\|empty\|push\|section\|can\|hasSection\|verbatim'
+let s:directives_start = 'if\|else\|unless\|for\|while\|empty\|push\|section\|can\|hasSection\|verbatim\|php'
 let s:directives_end = 'else\|end\|empty\|show\|stop\|append\|overwrite'
 
 if exists('g:blade_custom_directives_pairs')
@@ -27,53 +26,69 @@ endif
 
 setlocal autoindent
 setlocal indentexpr=GetBladeIndent()
-exe "setlocal indentkeys=o,O,<>>,!^F,0=}},0=!!},=@" . substitute(s:directives_end, '\\|', ',=@', 'g')
+exe 'setlocal indentkeys=o,O,<>>,!^F,0=}},0=!!},=@' . substitute(s:directives_end, '\\|', ',=@', 'g')
 
 " Only define the function once.
-if exists("*GetBladeIndent")
+if exists('*GetBladeIndent')
     finish
 endif
 
+function! s:IsStartingDelimiter(lnum)
+    let line = getline(a:lnum)
+    return line =~# '\%(\w\|@\)\@<!@\%(' . s:directives_start . '\)\%(.*@end\|.*@stop\)\@!'
+                \ || line =~# '{{\%(.*}}\)\@!'
+                \ || line =~# '{!!\%(.*!!}\)\@!'
+                \ || line =~# '<?\%(.*?>\)\@!'
+endfunction
+
 function! GetBladeIndent()
-    let lnum = prevnonblank(v:lnum-1)
+    let lnum = prevnonblank(v:lnum - 1)
     if lnum == 0
         return 0
     endif
 
-    let line = substitute(substitute(getline(lnum), '\s\+$', '', ''), '^\s\+', '', '')
-    let cline = substitute(substitute(getline(v:lnum), '\s\+$', '', ''), '^\s\+', '', '')
+    let line = getline(lnum)
+    let cline = getline(v:lnum)
     let indent = indent(lnum)
-    if cline =~# '@\%(' . s:directives_end . '\)' ||
-                \ cline =~# '\%(<?.*\)\@<!?>\|\%({{.*\)\@<!}}\|\%({!!.*\)\@<!!!}'
-        let indent = indent - &sw
-    elseif line =~# '<?\%(.*?>\)\@!\|@php\%(\s*(\)\@!'
-        let indent = indent + &sw
-    else
-        if exists("*GetBladeIndentCustom")
-            let hindent = GetBladeIndentCustom()
-        " Don't use PHP indentation if line is a comment
-        elseif line !~# '^\s*\%(#\|//\)\|\*/\s*$' && (
-                    \ searchpair('@include\%(If\)\?\s*(', '', ')', 'bWr') ||
-                    \ searchpair('{!!', '', '!!}', 'bWr') ||
-                    \ searchpair('{{', '', '}}', 'bWr') ||
-                    \ searchpair('<?', '', '?>', 'bWr') ||
-                    \ searchpair('@php\%(\s*(\)\@!', '', '@endphp', 'bWr') )
-            execute 'let hindent = ' . s:phpindent
-        else
-            execute 'let hindent = ' . s:htmlindent
-        endif
-        if hindent > -1
-            let indent = hindent
-        endif
-    endif
-    let increase = indent + &sw
 
-    if line =~# '@\%(section\)\%(.*@end\)\@!' && line !~# '@\%(section\)\s*([^,]*)'
-        return indent
-    elseif line =~# '@\%(' . s:directives_start . '\)\%(.*@end\|.*@stop\)\@!' ||
-                \ line =~# '{{\%(.*}}\)\@!' || line =~# '{!!\%(.*!!}\)\@!'
-        return increase
-    else
+    " 1. Check for special directives
+    " @section is a single-line directive if it has a second argument.
+    " @php is a single-line directive if it is followed by parentheses.
+    if (line =~# '@section\%(.*@end\)\@!' && line !~# '@section\s*([^,]*)')
+                \ || line =~# '@php\s*('
         return indent
     endif
+
+    " 2. When the current line is an ending delimiter: decrease indentation
+    "    if the previous line wasn't a starting delimiter.
+    if cline =~# '^\s*@\%(' . s:directives_end . '\)'
+                \ || cline =~# '\%(<?.*\)\@<!?>'
+                \ || cline =~# '\%({{.*\)\@<!}}'
+                \ || cline =~# '\%({!!.*\)\@<!!!}'
+        return s:IsStartingDelimiter(lnum) ? indent : indent - &sw
+    endif
+
+    " 3. Increase indentation if the line contains a starting delimiter.
+    if s:IsStartingDelimiter(lnum)
+        return indent + &sw
+    endif
+
+    " 4. External indent scripts (PHP and HTML)
+    execute 'let indent = ' . s:htmlindent
+
+    if exists('*GetBladeIndentCustom')
+        let indent = GetBladeIndentCustom()
+    elseif line !~# '^\s*\%(#\|//\)\|\*/\s*$' && (
+                \ searchpair('@include\%(If\)\?\s*(', '', ')', 'bWr') ||
+                \ searchpair('{!!', '', '!!}', 'bWr') ||
+                \ searchpair('{{', '', '}}', 'bWr') ||
+                \ searchpair('<?', '', '?>', 'bWr') ||
+                \ searchpair('@php\%(\s*(\)\@!', '', '@endphp', 'bWr') )
+        " Only use PHP's indent if the region spans multiple lines
+        if !s:IsStartingDelimiter(v:lnum)
+            execute 'let indent = ' . s:phpindent
+        endif
+    endif
+
+    return indent
 endfunction

--- a/syntax/blade.vim
+++ b/syntax/blade.vim
@@ -47,7 +47,7 @@ if exists('g:blade_custom_directives_pairs')
     exe "syn keyword bladeKeyword @" . join(values(g:blade_custom_directives_pairs), ' @') . " containedin=ALLBUT,@bladeExempt"
 endif
 
-syn region  bladePhpRegion  matchgroup=bladeKeyword start="\<@php\>\%(\s*(\)\@!" end="\<@endphp\>"  contains=@bladePhp  containedin=ALLBUT,@bladeExempt keepend
+syn region  bladePhpRegion  matchgroup=bladeKeyword start="\<@php\>\s*(\@!" end="\<@endphp\>"  contains=@bladePhp  containedin=ALLBUT,@bladeExempt keepend
 syn match   bladeKeyword "@php\ze\s*(" nextgroup=bladePhpParenBlock skipwhite containedin=ALLBUT,@bladeExempt
 
 syn region  bladePhpParenBlock  matchgroup=bladeDelimiter start="\s*(" end=")" contains=@bladePhp,bladePhpParenBlock skipwhite contained


### PR DESCRIPTION
- Refactor
- Fix #58: don't use PHP indentation if in spans over one line.
- Fix case where an e-mail address could be interpreted as a blade directive.
- PHP delimiters (`<?` `?>`, `@php` `@endphp`, `{{` `}}`) are now correctly indented if they do not contain PHP code yet.
- Added some helpful comments.

Also added component and slot directive to ftplugin and indent