### PR TITLE
Add @props directive to the default supported directives

### DIFF
--- a/syntax/blade.vim
+++ b/syntax/blade.vim
@@ -32,7 +32,7 @@ syn region  bladeComment    matchgroup=bladeDelimiter start="{{--" end="--}}"  c
 syn keyword bladeKeyword @if @elseif @foreach @forelse @for @while @can @cannot @elsecan @elsecannot @include
     \ @includeIf @each @inject @extends @section @stack @push @unless @yield @parent @hasSection @break @continue
     \ @unset @lang @choice @component @slot @prepend @json @isset @auth @guest @switch @case @includeFirst @empty
-    \ @includeWhen
+    \ @includeWhen @props
     \ nextgroup=bladePhpParenBlock skipwhite containedin=ALLBUT,@bladeExempt
 
 syn keyword bladeKeyword @else @endif @endunless @endfor @endforeach @endforelse @endwhile @endcan

--- a/test.blade.php
+++ b/test.blade.php
@@ -1,4 +1,4 @@
-@props(['foo' => 'bar'])
+@props(['foo' => 'bar', 'baz'])
 
 <?php if($foo='bar' ) { $something() } ?>
 Hello, {{ $name }}.

--- a/test.blade.php
+++ b/test.blade.php
@@ -1,3 +1,5 @@
+@props(['foo' => 'bar'])
+
 <?php if($foo='bar' ) { $something() } ?>
 Hello, {{ $name }}.
 


### PR DESCRIPTION
## Overview

This PR resolves #74 by adding the `@props` directive to the list of default supported directives.

The `@props` directive was supplied by Laravel as part of their Blade component upgrade ([docs here](/Users/alexandersix/.local/share/nvim/site/pack/packer/start/vim-blade)) as a way to pass data into anonymous components. For anyone unfamiliar, anonymous components are Blade components that are not backed by a PHP class and only consist of a Blade file. 

Since Laravel has added this directive directly into the framework, I think we ought to have it in this plugin as well!

## Additions

- Adds the `@props` directive to `syntax/blade.vim`
- Adds a test to `test.blade.php`

## Other Notes

I added the `@props` directive to the _top_ of the `test.blade.php` file because, typically, that's where the directive would go in everyday use.

I'm fairly certain that I added the directive to the correct spot in the syntax file, as it was working when I tested using the provided blade testing file, but I'm happy to move it somewhere else in the list if that would be preferable.

Thank you again for maintaining this package! It's an integral part to my Laravel development workflow, so I really appreciate it.